### PR TITLE
fix: include info count in GuardReport.to_dict()

### DIFF
--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -113,6 +113,7 @@ def test_guard_report_filter():
 def test_guard_report_to_json():
     report = GuardReport(
         critical=[Issue("leakage", "LEK001", CRITICAL, "Test.", "Col")],
+        info=[Issue("profiler", "PRF001", "info", "Info test.", "Col2")],
         metadata={"rows": 50},
     )
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
@@ -122,17 +123,25 @@ def test_guard_report_to_json():
         with open(path) as f:
             data = json.load(f)
         assert data["counts"]["critical"] == 1
+        assert data["counts"]["info"] == 1
+        assert data["counts"] == report.to_dict()["counts"]
         assert data["issues"][0]["code"] == "LEK001"
     finally:
         os.unlink(path)
 
 
 def test_guard_report_to_dict():
-    report = GuardReport(metadata={"rows": 10})
+    report = GuardReport(
+        critical=[Issue("leakage", "LEK001", CRITICAL, "Test.", "Col")],
+        warnings=[Issue("profiler", "PRF002", WARNING, "Warn.", "Col")],
+        info=[Issue("profiler", "PRF001", "info", "Info test.", "Col2")],
+        metadata={"rows": 10},
+    )
     d = report.to_dict()
     assert "metadata" in d
     assert "issues" in d
     assert "counts" in d
+    assert d["counts"] == {"critical": 1, "warnings": 1, "info": 1}
 
 
 # ── Validation ────────────────────────────────────────────────────────────────

--- a/tsauditor/report/summary.py
+++ b/tsauditor/report/summary.py
@@ -516,5 +516,6 @@ class GuardReport:
             "counts": {
                 "critical": len(self.critical),
                 "warnings": len(self.warnings),
+                "info": len(self.info),
             },
         }


### PR DESCRIPTION
Fixes #43

### Summary of Changes
- Added `"info": len(self.info)` to `GuardReport.to_dict()` counts payload to match `to_json()`.
- Updated unit tests in `tests/test_scaffold.py` to assert parity between `to_dict()` and `to_json()` count dictionaries.