### PR TITLE
fix(report): include info count in GuardReport.to_dict()

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,7 +3,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from tsauditor.report.summary import GuardReport, Issue, WARNING, CRITICAL
+from tsauditor.report.summary import GuardReport, Issue, WARNING, CRITICAL, INFO
 
 
 def _idx(n):
@@ -76,3 +76,18 @@ def test_to_json_backward_compatible_without_df(tmp_path):
     assert "health" not in data
     assert data["issues"][0]["code"] == "LEK001"
     assert data["leaky_columns"] == ["x"]
+
+
+def test_to_dict_counts_include_info_and_match_json(tmp_path):
+    """to_dict()["counts"] must include info and agree with the to_json() payload."""
+    rep = GuardReport(
+        critical=[Issue("leakage", "LEK001", CRITICAL, "eq", "x")],
+        warnings=[Issue("profiler", "PRF002", WARNING, "clustered", "a")],
+        info=[Issue("profiler", "PRF010", INFO, "note", "b")],
+    )
+    p = tmp_path / "r.json"
+    rep.to_json(str(p))
+    payload = json.loads(p.read_text())
+    counts = rep.to_dict()["counts"]
+    assert counts == payload["counts"]
+    assert counts == {"critical": 1, "warnings": 1, "info": 1}

--- a/tsauditor/report/summary.py
+++ b/tsauditor/report/summary.py
@@ -516,5 +516,6 @@ class GuardReport:
             "counts": {
                 "critical": len(self.critical),
                 "warnings": len(self.warnings),
+                "info": len(self.info),
             },
         }


### PR DESCRIPTION
## What
`GuardReport.to_dict()["counts"]` reported only `critical` and `warnings`, while `to_json()` also includes `info`. Anyone reading `counts` from `to_dict()` saw a total that did not match the report.

## Change
- Add `"info": len(self.info)` to the `counts` dict in `to_dict()` (mirrors `to_json()` a few lines above).
- Add a test asserting `to_dict()["counts"]` agrees with the `to_json()` payload.

## Verification
Full suite passes locally: `378 passed`.

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)