### PR TITLE
Fix: include info count in GuardReport.to_dict()

### DIFF
--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -138,7 +138,9 @@ def test_guard_report_to_dict():
 def test_guard_report_to_dict_counts_match_to_json():
     report = GuardReport(
         critical=[Issue("leakage", "LEK001", CRITICAL, "Test.", "Col")],
-        warnings=[Issue("profiler", "PRF001", WARNING, "Irregular frequency.", "Price")],
+        warnings=[
+            Issue("profiler", "PRF001", WARNING, "Irregular frequency.", "Price")
+        ],
         info=[Issue("profiler", "PRF003", INFO, "Note.", "Price")],
         metadata={"rows": 10},
     )

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -138,8 +138,8 @@ def test_guard_report_to_dict():
 def test_guard_report_to_dict_counts_match_to_json():
     report = GuardReport(
         critical=[Issue("leakage", "LEK001", CRITICAL, "Test.", "Col")],
-        warnings=[Issue("profiler", "PRF003", WARNING, "Non-stationary.", "Price")],
-        info=[Issue("profiler", "PRF010", INFO, "Note.", "Price")],
+        warnings=[Issue("profiler", "PRF001", WARNING, "Irregular frequency.", "Price")],
+        info=[Issue("profiler", "PRF001", INFO, "Note.", "Price")],
         metadata={"rows": 10},
     )
     d = report.to_dict()

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 import tsauditor as tsa
-from tsauditor.report.summary import GuardReport, Issue, CRITICAL, WARNING
+from tsauditor.report.summary import GuardReport, Issue, CRITICAL, WARNING, INFO
 from tsauditor.utils.validation import validate_dataframe, infer_frequency
 
 
@@ -133,6 +133,27 @@ def test_guard_report_to_dict():
     assert "metadata" in d
     assert "issues" in d
     assert "counts" in d
+
+
+def test_guard_report_to_dict_counts_match_to_json():
+    report = GuardReport(
+        critical=[Issue("leakage", "LEK001", CRITICAL, "Test.", "Col")],
+        warnings=[Issue("profiler", "PRF003", WARNING, "Non-stationary.", "Price")],
+        info=[Issue("profiler", "PRF010", INFO, "Note.", "Price")],
+        metadata={"rows": 10},
+    )
+    d = report.to_dict()
+    assert d["counts"] == {"critical": 1, "warnings": 1, "info": 1}
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        path = f.name
+    try:
+        report.to_json(path)
+        with open(path) as f:
+            json_counts = json.load(f)["counts"]
+        assert d["counts"] == json_counts
+    finally:
+        os.unlink(path)
 
 
 # ── Validation ────────────────────────────────────────────────────────────────

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -139,7 +139,7 @@ def test_guard_report_to_dict_counts_match_to_json():
     report = GuardReport(
         critical=[Issue("leakage", "LEK001", CRITICAL, "Test.", "Col")],
         warnings=[Issue("profiler", "PRF001", WARNING, "Irregular frequency.", "Price")],
-        info=[Issue("profiler", "PRF001", INFO, "Note.", "Price")],
+        info=[Issue("profiler", "PRF003", INFO, "Note.", "Price")],
         metadata={"rows": 10},
     )
     d = report.to_dict()

--- a/tsauditor/report/summary.py
+++ b/tsauditor/report/summary.py
@@ -516,5 +516,6 @@ class GuardReport:
             "counts": {
                 "critical": len(self.critical),
                 "warnings": len(self.warnings),
+                "info": len(self.info),
             },
         }


### PR DESCRIPTION
## Summary
- `GuardReport.to_dict()` only reported `critical` and `warnings` counts, while `to_json()` also includes `info`. Anyone reading counts from `to_dict()` saw a total that didn't match the report.
- Added `"info": len(self.info)` to the `counts` dict in `to_dict()`.
- Added a test asserting `to_dict()["counts"]` and the `to_json()` payload's counts agree.

Fixes #43

## Test plan
- [x] `pytest tests/test_scaffold.py -q` — 20 passed
- [x] Full suite: `pytest tests -q` — 378 passed, no regressions