### PR TITLE
Adding an example notebook for opencv temporal use case

### DIFF
--- a/examples/opencv-example/tsauditor_opencv_pose_example.ipynb
+++ b/examples/opencv-example/tsauditor_opencv_pose_example.ipynb
@@ -1,307 +1,341 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "OF65oHC2J-mr"
-      },
-      "source": [
-        "# tsauditor Example: Auditing Video Pose Keypoint Time Series\n",
-        "\n",
-        "A non-finance, non-sensor use case: auditing per-person pose keypoint sequences extracted from video (YOLOv8-pose + tracking) for an action recognition pipeline. Each tracked person becomes one panel entity; their per-frame skeleton (17 COCO keypoints, 34 x/y values) is the time series.\n",
-        "\n",
-        "This notebook uses **synthetic data** so it runs standalone. The real case study that motivated this example is described in the markdown cells below.\n"
-      ],
-      "id": "OF65oHC2J-mr"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "RS1AIlDBJ-mv"
-      },
-      "source": [
-        "## 1. Generate synthetic pose data\n",
-        "\n",
-        "Simulates the same shape as real extracted data: some tracks with natural jittery motion, and, deliberately, a few tracks with an injected **boundary-clamp artifact** (a keypoint pinned to a constant value for many consecutive frames), matching the real bug this example is based on.\n"
-      ],
-      "id": "RS1AIlDBJ-mv"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "ftYTKvu2J-mv",
-        "outputId": "522be6c6-a852-45d7-a356-6d06ce673b5d"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "20 tracks generated (15 natural, 5 with injected clamp artifact).\n"
-          ]
-        }
-      ],
-      "source": [
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "\n",
-        "np.random.seed(42)\n",
-        "NUM_KEYPOINTS = 17\n",
-        "FPS = 15\n",
-        "\n",
-        "def make_natural_track(n_frames, track_id):\n",
-        "    \"\"\"Normal case: every joint jitters naturally frame to frame.\"\"\"\n",
-        "    base = np.random.uniform(-1, 1, size=(NUM_KEYPOINTS, 2))\n",
-        "    kp = base[None, :, :] + np.random.normal(0, 0.02, size=(n_frames, NUM_KEYPOINTS, 2)).cumsum(axis=0) * 0.1\n",
-        "    return kp\n",
-        "\n",
-        "def make_clamped_track(n_frames, track_id, clamp_joint=15, clamp_value=1.0, clamp_start=10, clamp_len=40):\n",
-        "    \"\"\"Injects the real bug: one joint's y-coordinate gets pinned to a\n",
-        "    constant value for a stretch of frames, mimicking YOLOv8-pose\n",
-        "    clamping an off-screen keypoint to the frame boundary.\"\"\"\n",
-        "    kp = make_natural_track(n_frames, track_id)\n",
-        "    end = min(clamp_start + clamp_len, n_frames)\n",
-        "    kp[clamp_start:end, clamp_joint, 1] = clamp_value  # y-coordinate pinned\n",
-        "    return kp\n",
-        "\n",
-        "frames = {}\n",
-        "\n",
-        "# 15 well-behaved tracks\n",
-        "for i in range(15):\n",
-        "    n = np.random.randint(40, 90)\n",
-        "    kp = make_natural_track(n, i)\n",
-        "    rows = [{\"frame_idx\": t, **{f\"kp{j}_{ax}\": kp[t, j, k]\n",
-        "             for j in range(NUM_KEYPOINTS) for k, ax in enumerate(\"xy\")}}\n",
-        "            for t in range(n)]\n",
-        "    df = pd.DataFrame(rows)\n",
-        "    df[\"timestamp\"] = pd.Timestamp(\"2000-01-01\") + pd.to_timedelta(df[\"frame_idx\"] / FPS, unit=\"s\")\n",
-        "    frames[f\"natural_track_{i}\"] = df.set_index(\"timestamp\").drop(columns=[\"frame_idx\"])\n",
-        "\n",
-        "# 5 tracks with the injected boundary-clamp artifact\n",
-        "for i in range(5):\n",
-        "    n = np.random.randint(50, 90)\n",
-        "    kp = make_clamped_track(n, i)\n",
-        "    rows = [{\"frame_idx\": t, **{f\"kp{j}_{ax}\": kp[t, j, k]\n",
-        "             for j in range(NUM_KEYPOINTS) for k, ax in enumerate(\"xy\")}}\n",
-        "            for t in range(n)]\n",
-        "    df = pd.DataFrame(rows)\n",
-        "    df[\"timestamp\"] = pd.Timestamp(\"2000-01-01\") + pd.to_timedelta(df[\"frame_idx\"] / FPS, unit=\"s\")\n",
-        "    frames[f\"clamped_track_{i}\"] = df.set_index(\"timestamp\").drop(columns=[\"frame_idx\"])\n",
-        "\n",
-        "print(f\"{len(frames)} tracks generated ({15} natural, {5} with injected clamp artifact).\")\n"
-      ],
-      "id": "ftYTKvu2J-mv"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VMLNg1-5J-my"
-      },
-      "source": [
-        "## 2. Audit each track in parallel\n",
-        "\n",
-        "With ~20 short entities (this toy example) or thousands (a real extraction run), `group_col` on one combined long-format frame hits real per-task overhead once entities are numerous and short. Using separate per-entity DataFrames with the documented joblib pattern scales better for this shape of data.\n",
-        "\n",
-        "`target=None` is deliberate: there's no per-frame prediction target here (a track's label, if any, is one scalar for the whole sequence, not per-row), so leakage checks are correctly skipped, not worked around.\n"
-      ],
-      "id": "VMLNg1-5J-my"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "GRg3ECKeJ-mz"
-      },
-      "outputs": [],
-      "source": [
-        "from joblib import Parallel, delayed\n",
-        "import tsauditor as tsa\n",
-        "\n",
-        "def audit_track(track_id, df):\n",
-        "    report = tsa.scan(df, target=None, domain=\"sensor\",\n",
-        "                       run_leakage=False, run_stationarity=False)\n",
-        "    return track_id, report\n",
-        "\n",
-        "results = dict(Parallel(n_jobs=-1)(\n",
-        "    delayed(audit_track)(tid, df) for tid, df in frames.items()\n",
-        "))\n"
-      ],
-      "id": "GRg3ECKeJ-mz"
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "!pip install tsauditor"
-      ],
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4Xf13Re8KRpl",
-        "outputId": "cc15d6c8-8278-4111-988c-b2c8b6ae0032"
-      },
-      "id": "4Xf13Re8KRpl",
-      "execution_count": 2,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Collecting tsauditor\n",
-            "  Downloading tsauditor-0.4.0-py3-none-any.whl.metadata (25 kB)\n",
-            "Requirement already satisfied: pandas<3,>=1.5 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (2.2.2)\n",
-            "Requirement already satisfied: numpy<3,>=1.23 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (2.0.2)\n",
-            "Requirement already satisfied: scipy<2,>=1.9 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (1.16.3)\n",
-            "Requirement already satisfied: statsmodels<1,>=0.13 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (0.14.6)\n",
-            "Requirement already satisfied: rich<16,>=13.0 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (13.9.4)\n",
-            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2.9.0.post0)\n",
-            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2025.2)\n",
-            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2026.3)\n",
-            "Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.12/dist-packages (from rich<16,>=13.0->tsauditor) (4.2.0)\n",
-            "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.12/dist-packages (from rich<16,>=13.0->tsauditor) (2.20.0)\n",
-            "Requirement already satisfied: patsy>=0.5.6 in /usr/local/lib/python3.12/dist-packages (from statsmodels<1,>=0.13->tsauditor) (1.0.2)\n",
-            "Requirement already satisfied: packaging>=21.3 in /usr/local/lib/python3.12/dist-packages (from statsmodels<1,>=0.13->tsauditor) (26.2)\n",
-            "Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.12/dist-packages (from markdown-it-py>=2.2.0->rich<16,>=13.0->tsauditor) (0.1.2)\n",
-            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas<3,>=1.5->tsauditor) (1.17.0)\n",
-            "Downloading tsauditor-0.4.0-py3-none-any.whl (82 kB)\n",
-            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m82.8/82.8 kB\u001b[0m \u001b[31m3.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-            "\u001b[?25hInstalling collected packages: tsauditor\n",
-            "Successfully installed tsauditor-0.4.0\n"
-          ]
-        }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tPUo1OeXJ-mz"
-      },
-      "source": [
-        "## 3. Collect ANO001 (stuck value) findings"
-      ],
-      "id": "tPUo1OeXJ-mz"
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "XsXdbqNGJ-m0",
-        "outputId": "a9246c9c-fbde-4d24-c12a-ac0e636536a1"
-      },
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "5 ANO001 findings across 20 tracks:\n",
-            "\n",
-            "  clamped_track_0: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
-            "  clamped_track_1: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
-            "  clamped_track_2: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
-            "  clamped_track_3: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
-            "  clamped_track_4: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n"
-          ]
-        }
-      ],
-      "source": [
-        "stuck = []\n",
-        "for track_id, report in results.items():\n",
-        "    for issue in (report.critical + report.warnings + report.info):\n",
-        "        if \"ANO001\" in str(getattr(issue, \"code\", \"\")):\n",
-        "            stuck.append((track_id, issue))\n",
-        "\n",
-        "print(f\"{len(stuck)} ANO001 findings across {len(frames)} tracks:\\n\")\n",
-        "for track_id, issue in stuck:\n",
-        "    print(f\"  {track_id}: {issue}\")\n"
-      ],
-      "id": "XsXdbqNGJ-m0"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "h2ttoZOVJ-m0"
-      },
-      "source": [
-        "Notice it correctly catches the 5 `clamped_track_*` entities (and correctly leaves the 15 `natural_track_*` entities alone), exactly matching what happened on the real dataset this example is based on.\n"
-      ],
-      "id": "h2ttoZOVJ-m0"
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "R11fLaJlJ-m1"
-      },
-      "source": [
-        "## 4. The real case study\n",
-        "\n",
-        "This synthetic example is modeled on a real bug found and fixed while building an unrelated project: a fight and agitation detection pipeline for CCTV monitoring, intended to eventually support detecting sudden aggression in dementia and Parkinson's patients in care settings.\n",
-        "\n",
-        "### Background\n",
-        "\n",
-        "That pipeline extracts human pose keypoints from video using YOLOv8-pose, tracks each person across frames with ByteTrack, and classifies each tracked person's motion sequence with an LSTM as aggressive or calm. Roughly 3600 tracked people were extracted from about 2000 video clips (the RLVS dataset). Each tracked person's keypoints were normalized (centered on hip midpoint, scaled by shoulder width) and cached as a sequence for training.\n",
-        "\n",
-        "### Why tsuditor was applied here\n",
-        "\n",
-        "tsauditor was originally built for financial and sensor time series, not video pose data. It was applied to this pipeline's output anyway, because the underlying data shape is the same regardless of domain: each tracked person is an independent panel entity, and their per-frame keypoints form a time series for that entity. The question TSAuditor answers, is anything in this time series behaving in a way that shouldn't happen, applies just as well to a skeleton's joint position over time as it does to a stock's price over time.\n",
-        "\n",
-        "The specific check of interest was ANO001, stuck value detection. The concern was a known failure mode in this kind of pipeline: if pose tracking silently stalls (loses the person but keeps reporting a value) rather than failing cleanly, the resulting sequence looks like real data but isn't. A frame where every keypoint is exactly zero is easy to catch and already was, but a subtler stall, where the model keeps reporting a plausible-looking but frozen position, is much harder to catch by eye and was not something the pipeline's existing checks looked for.\n",
-        "\n",
-        "### What the audit found\n",
-        "\n",
-        "Each of the roughly 3600 tracked people's keypoint sequences was converted into its own DataFrame and audited independently, in parallel, using the pattern shown in section 2 of this notebook. The scan flagged 1099 ANO001 findings. Nearly all of them were on vertical (y-axis) coordinate columns, and several tracks showed a joint holding the exact same value for over 50 consecutive frames, out of tracks that were themselves often only 50 to 90 frames long. In other words, some tracked people had a joint that never moved for essentially the entire time they were tracked.\n",
-        "\n",
-        "### Investigating the finding\n",
-        "\n",
-        "The first hypothesis was tracking failure: perhaps ByteTrack was losing the person and re-detecting a static background object under the same ID. This was ruled out by inspecting the raw, pre-normalization keypoint values for a flagged track directly, rather than only looking at the normalized, already processed data. The raw dump showed something more specific:\n",
-        "\n",
-        "```\n",
-        "frame 0: kp7(elbow)=[168.95  224]  kp11(hip)=[122.72  224]  kp15(ankle)=[117.84  224]\n",
-        "frame 1: kp7(elbow)=[166.73  224]  kp11(hip)=[122.44  224]  kp15(ankle)=[114.75  224]\n",
-        "frame 2: kp7(elbow)=[165.50  224]  kp11(hip)=[120.85  224]  kp12(hip)=[114.13  224]\n",
-        "...\n",
-        "```\n",
-        "\n",
-        "The x-coordinates were changing naturally, frame to frame, consistent with a real, moving person. The y-coordinates, across several unrelated joints (elbow, both hips, ankle), were pinned to exactly 224. Checking the source video's actual pixel height confirmed it: 224 pixels. That is not a coincidence, it is the frame boundary.\n",
-        "\n",
-        "### Root cause\n",
-        "\n",
-        "YOLOv8-pose, when a tracked person's body extends beyond the visible edge of the frame (a very common situation in close-up or partially cropped CCTV and street-level footage), does not mark the corresponding keypoint as undetected. Instead, it reports a keypoint clamped to the frame boundary, as if that were a normal, confident detection. Because the reported value is a real, non-zero coordinate rather than (0, 0), it passes straight through a simple all-zero detection-failure filter undetected. It also looks fine in a visual sanity check, since a skeleton plot of a single frame with a boundary-clamped ankle still looks like a plausible human pose. The problem only becomes visible when checking whether a value that should vary over time is actually varying, which is exactly what TSAuditor's stuck value check does.\n",
-        "\n",
-        "### Fix\n",
-        "\n",
-        "The pipeline's normalization step was updated to reject any frame where a keypoint sits within about one pixel of the frame boundary, in addition to the existing all-zero check. This is a targeted fix aimed specifically at the confirmed cause, rather than a broader change to tracking or detection logic.\n",
-        "\n",
-        "### Verification\n",
-        "\n",
-        "The full dataset was re-extracted with the fix in place, and the identical tsauditor scan was re-run against the corrected data. The result: zero ANO001 findings, across 3345 tracked people (down from 3617, since the tracks that consisted mostly of the fake boundary-clamped signal are now correctly excluded rather than silently retained). This before-and-after comparison, same check, same underlying pipeline, only the fix applied in between, is what confirms the fix actually resolved the underlying issue rather than only hiding its symptom.\n",
-        "\n",
-        "### Takeaway\n",
-        "\n",
-        "ANO001 is not a finance-specific or sensor-specific check. The underlying idea, a value that is supposed to vary should not be constant, applies equally to a stock price, a temperature reading, or a joint's position in a video. The specific failure mode found here (a computer vision model clamping instead of failing) looks nothing like a typical financial data quality issue, but it produces the exact same statistical signature that tsauditor was already built to catch.\n"
-      ],
-      "id": "R11fLaJlJ-m1"
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "OF65oHC2J-mr",
+   "metadata": {
+    "id": "OF65oHC2J-mr"
+   },
+   "source": [
+    "# tsauditor Example: Auditing Video Pose Keypoint Time Series\n",
+    "\n",
+    "A non-finance, non-sensor use case: auditing per-person pose keypoint sequences extracted from video (YOLOv8-pose + tracking) for an action recognition pipeline. Each tracked person becomes one panel entity; their per-frame skeleton (17 COCO keypoints, 34 x/y values) is the time series.\n",
+    "\n",
+    "This notebook uses **synthetic data** so it runs standalone. The real case study that motivated this example is described in the markdown cells below.\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "RS1AIlDBJ-mv",
+   "metadata": {
+    "id": "RS1AIlDBJ-mv"
+   },
+   "source": [
+    "## 1. Generate synthetic pose data\n",
+    "\n",
+    "Simulates the same shape as real extracted data: some tracks with natural jittery motion, and, deliberately, a few tracks with an injected **boundary-clamp artifact** (a keypoint pinned to a constant value for many consecutive frames), matching the real bug this example is based on.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ftYTKvu2J-mv",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "ftYTKvu2J-mv",
+    "outputId": "522be6c6-a852-45d7-a356-6d06ce673b5d"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20 tracks generated (15 natural, 5 with injected clamp artifact).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "np.random.seed(42)\n",
+    "NUM_KEYPOINTS = 17\n",
+    "FPS = 15\n",
+    "\n",
+    "\n",
+    "def make_natural_track(n_frames, track_id):\n",
+    "    \"\"\"Normal case: every joint jitters naturally frame to frame.\"\"\"\n",
+    "    base = np.random.uniform(-1, 1, size=(NUM_KEYPOINTS, 2))\n",
+    "    kp = (\n",
+    "        base[None, :, :]\n",
+    "        + np.random.normal(0, 0.02, size=(n_frames, NUM_KEYPOINTS, 2)).cumsum(axis=0)\n",
+    "        * 0.1\n",
+    "    )\n",
+    "    return kp\n",
+    "\n",
+    "\n",
+    "def make_clamped_track(\n",
+    "    n_frames, track_id, clamp_joint=15, clamp_value=1.0, clamp_start=10, clamp_len=40\n",
+    "):\n",
+    "    \"\"\"Injects the real bug: one joint's y-coordinate gets pinned to a\n",
+    "    constant value for a stretch of frames, mimicking YOLOv8-pose\n",
+    "    clamping an off-screen keypoint to the frame boundary.\"\"\"\n",
+    "    kp = make_natural_track(n_frames, track_id)\n",
+    "    end = min(clamp_start + clamp_len, n_frames)\n",
+    "    kp[clamp_start:end, clamp_joint, 1] = clamp_value  # y-coordinate pinned\n",
+    "    return kp\n",
+    "\n",
+    "\n",
+    "frames = {}\n",
+    "\n",
+    "# 15 well-behaved tracks\n",
+    "for i in range(15):\n",
+    "    n = np.random.randint(40, 90)\n",
+    "    kp = make_natural_track(n, i)\n",
+    "    rows = [\n",
+    "        {\n",
+    "            \"frame_idx\": t,\n",
+    "            **{\n",
+    "                f\"kp{j}_{ax}\": kp[t, j, k]\n",
+    "                for j in range(NUM_KEYPOINTS)\n",
+    "                for k, ax in enumerate(\"xy\")\n",
+    "            },\n",
+    "        }\n",
+    "        for t in range(n)\n",
+    "    ]\n",
+    "    df = pd.DataFrame(rows)\n",
+    "    df[\"timestamp\"] = pd.Timestamp(\"2000-01-01\") + pd.to_timedelta(\n",
+    "        df[\"frame_idx\"] / FPS, unit=\"s\"\n",
+    "    )\n",
+    "    frames[f\"natural_track_{i}\"] = df.set_index(\"timestamp\").drop(columns=[\"frame_idx\"])\n",
+    "\n",
+    "# 5 tracks with the injected boundary-clamp artifact\n",
+    "for i in range(5):\n",
+    "    n = np.random.randint(50, 90)\n",
+    "    kp = make_clamped_track(n, i)\n",
+    "    rows = [\n",
+    "        {\n",
+    "            \"frame_idx\": t,\n",
+    "            **{\n",
+    "                f\"kp{j}_{ax}\": kp[t, j, k]\n",
+    "                for j in range(NUM_KEYPOINTS)\n",
+    "                for k, ax in enumerate(\"xy\")\n",
+    "            },\n",
+    "        }\n",
+    "        for t in range(n)\n",
+    "    ]\n",
+    "    df = pd.DataFrame(rows)\n",
+    "    df[\"timestamp\"] = pd.Timestamp(\"2000-01-01\") + pd.to_timedelta(\n",
+    "        df[\"frame_idx\"] / FPS, unit=\"s\"\n",
+    "    )\n",
+    "    frames[f\"clamped_track_{i}\"] = df.set_index(\"timestamp\").drop(columns=[\"frame_idx\"])\n",
+    "\n",
+    "print(\n",
+    "    f\"{len(frames)} tracks generated ({15} natural, {5} with injected clamp artifact).\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "VMLNg1-5J-my",
+   "metadata": {
+    "id": "VMLNg1-5J-my"
+   },
+   "source": [
+    "## 2. Audit each track in parallel\n",
+    "\n",
+    "With ~20 short entities (this toy example) or thousands (a real extraction run), `group_col` on one combined long-format frame hits real per-task overhead once entities are numerous and short. Using separate per-entity DataFrames with the documented joblib pattern scales better for this shape of data.\n",
+    "\n",
+    "`target=None` is deliberate: there's no per-frame prediction target here (a track's label, if any, is one scalar for the whole sequence, not per-row), so leakage checks are correctly skipped, not worked around.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "GRg3ECKeJ-mz",
+   "metadata": {
+    "id": "GRg3ECKeJ-mz"
+   },
+   "outputs": [],
+   "source": [
+    "from joblib import Parallel, delayed\n",
+    "import tsauditor as tsa\n",
+    "\n",
+    "\n",
+    "def audit_track(track_id, df):\n",
+    "    report = tsa.scan(\n",
+    "        df, target=None, domain=\"sensor\", run_leakage=False, run_stationarity=False\n",
+    "    )\n",
+    "    return track_id, report\n",
+    "\n",
+    "\n",
+    "results = dict(\n",
+    "    Parallel(n_jobs=-1)(delayed(audit_track)(tid, df) for tid, df in frames.items())\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4Xf13Re8KRpl",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "4Xf13Re8KRpl",
+    "outputId": "cc15d6c8-8278-4111-988c-b2c8b6ae0032"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting tsauditor\n",
+      "  Downloading tsauditor-0.4.0-py3-none-any.whl.metadata (25 kB)\n",
+      "Requirement already satisfied: pandas<3,>=1.5 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (2.2.2)\n",
+      "Requirement already satisfied: numpy<3,>=1.23 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (2.0.2)\n",
+      "Requirement already satisfied: scipy<2,>=1.9 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (1.16.3)\n",
+      "Requirement already satisfied: statsmodels<1,>=0.13 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (0.14.6)\n",
+      "Requirement already satisfied: rich<16,>=13.0 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (13.9.4)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2.9.0.post0)\n",
+      "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2025.2)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2026.3)\n",
+      "Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.12/dist-packages (from rich<16,>=13.0->tsauditor) (4.2.0)\n",
+      "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.12/dist-packages (from rich<16,>=13.0->tsauditor) (2.20.0)\n",
+      "Requirement already satisfied: patsy>=0.5.6 in /usr/local/lib/python3.12/dist-packages (from statsmodels<1,>=0.13->tsauditor) (1.0.2)\n",
+      "Requirement already satisfied: packaging>=21.3 in /usr/local/lib/python3.12/dist-packages (from statsmodels<1,>=0.13->tsauditor) (26.2)\n",
+      "Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.12/dist-packages (from markdown-it-py>=2.2.0->rich<16,>=13.0->tsauditor) (0.1.2)\n",
+      "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas<3,>=1.5->tsauditor) (1.17.0)\n",
+      "Downloading tsauditor-0.4.0-py3-none-any.whl (82 kB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m82.8/82.8 kB\u001b[0m \u001b[31m3.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: tsauditor\n",
+      "Successfully installed tsauditor-0.4.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install tsauditor"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tPUo1OeXJ-mz",
+   "metadata": {
+    "id": "tPUo1OeXJ-mz"
+   },
+   "source": [
+    "## 3. Collect ANO001 (stuck value) findings"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "XsXdbqNGJ-m0",
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/"
+    },
+    "id": "XsXdbqNGJ-m0",
+    "outputId": "a9246c9c-fbde-4d24-c12a-ac0e636536a1"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5 ANO001 findings across 20 tracks:\n",
+      "\n",
+      "  clamped_track_0: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+      "  clamped_track_1: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+      "  clamped_track_2: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+      "  clamped_track_3: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+      "  clamped_track_4: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n"
+     ]
+    }
+   ],
+   "source": [
+    "stuck = []\n",
+    "for track_id, report in results.items():\n",
+    "    for issue in report.critical + report.warnings + report.info:\n",
+    "        if \"ANO001\" in str(getattr(issue, \"code\", \"\")):\n",
+    "            stuck.append((track_id, issue))\n",
+    "\n",
+    "print(f\"{len(stuck)} ANO001 findings across {len(frames)} tracks:\\n\")\n",
+    "for track_id, issue in stuck:\n",
+    "    print(f\"  {track_id}: {issue}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "h2ttoZOVJ-m0",
+   "metadata": {
+    "id": "h2ttoZOVJ-m0"
+   },
+   "source": [
+    "Notice it correctly catches the 5 `clamped_track_*` entities (and correctly leaves the 15 `natural_track_*` entities alone), exactly matching what happened on the real dataset this example is based on.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "R11fLaJlJ-m1",
+   "metadata": {
+    "id": "R11fLaJlJ-m1"
+   },
+   "source": [
+    "## 4. The real case study\n",
+    "\n",
+    "This synthetic example is modeled on a real bug found and fixed while building an unrelated project: a fight and agitation detection pipeline for CCTV monitoring, intended to eventually support detecting sudden aggression in dementia and Parkinson's patients in care settings.\n",
+    "\n",
+    "### Background\n",
+    "\n",
+    "That pipeline extracts human pose keypoints from video using YOLOv8-pose, tracks each person across frames with ByteTrack, and classifies each tracked person's motion sequence with an LSTM as aggressive or calm. Roughly 3600 tracked people were extracted from about 2000 video clips (the RLVS dataset). Each tracked person's keypoints were normalized (centered on hip midpoint, scaled by shoulder width) and cached as a sequence for training.\n",
+    "\n",
+    "### Why tsuditor was applied here\n",
+    "\n",
+    "tsauditor was originally built for financial and sensor time series, not video pose data. It was applied to this pipeline's output anyway, because the underlying data shape is the same regardless of domain: each tracked person is an independent panel entity, and their per-frame keypoints form a time series for that entity. The question TSAuditor answers, is anything in this time series behaving in a way that shouldn't happen, applies just as well to a skeleton's joint position over time as it does to a stock's price over time.\n",
+    "\n",
+    "The specific check of interest was ANO001, stuck value detection. The concern was a known failure mode in this kind of pipeline: if pose tracking silently stalls (loses the person but keeps reporting a value) rather than failing cleanly, the resulting sequence looks like real data but isn't. A frame where every keypoint is exactly zero is easy to catch and already was, but a subtler stall, where the model keeps reporting a plausible-looking but frozen position, is much harder to catch by eye and was not something the pipeline's existing checks looked for.\n",
+    "\n",
+    "### What the audit found\n",
+    "\n",
+    "Each of the roughly 3600 tracked people's keypoint sequences was converted into its own DataFrame and audited independently, in parallel, using the pattern shown in section 2 of this notebook. The scan flagged 1099 ANO001 findings. Nearly all of them were on vertical (y-axis) coordinate columns, and several tracks showed a joint holding the exact same value for over 50 consecutive frames, out of tracks that were themselves often only 50 to 90 frames long. In other words, some tracked people had a joint that never moved for essentially the entire time they were tracked.\n",
+    "\n",
+    "### Investigating the finding\n",
+    "\n",
+    "The first hypothesis was tracking failure: perhaps ByteTrack was losing the person and re-detecting a static background object under the same ID. This was ruled out by inspecting the raw, pre-normalization keypoint values for a flagged track directly, rather than only looking at the normalized, already processed data. The raw dump showed something more specific:\n",
+    "\n",
+    "```\n",
+    "frame 0: kp7(elbow)=[168.95  224]  kp11(hip)=[122.72  224]  kp15(ankle)=[117.84  224]\n",
+    "frame 1: kp7(elbow)=[166.73  224]  kp11(hip)=[122.44  224]  kp15(ankle)=[114.75  224]\n",
+    "frame 2: kp7(elbow)=[165.50  224]  kp11(hip)=[120.85  224]  kp12(hip)=[114.13  224]\n",
+    "...\n",
+    "```\n",
+    "\n",
+    "The x-coordinates were changing naturally, frame to frame, consistent with a real, moving person. The y-coordinates, across several unrelated joints (elbow, both hips, ankle), were pinned to exactly 224. Checking the source video's actual pixel height confirmed it: 224 pixels. That is not a coincidence, it is the frame boundary.\n",
+    "\n",
+    "### Root cause\n",
+    "\n",
+    "YOLOv8-pose, when a tracked person's body extends beyond the visible edge of the frame (a very common situation in close-up or partially cropped CCTV and street-level footage), does not mark the corresponding keypoint as undetected. Instead, it reports a keypoint clamped to the frame boundary, as if that were a normal, confident detection. Because the reported value is a real, non-zero coordinate rather than (0, 0), it passes straight through a simple all-zero detection-failure filter undetected. It also looks fine in a visual sanity check, since a skeleton plot of a single frame with a boundary-clamped ankle still looks like a plausible human pose. The problem only becomes visible when checking whether a value that should vary over time is actually varying, which is exactly what TSAuditor's stuck value check does.\n",
+    "\n",
+    "### Fix\n",
+    "\n",
+    "The pipeline's normalization step was updated to reject any frame where a keypoint sits within about one pixel of the frame boundary, in addition to the existing all-zero check. This is a targeted fix aimed specifically at the confirmed cause, rather than a broader change to tracking or detection logic.\n",
+    "\n",
+    "### Verification\n",
+    "\n",
+    "The full dataset was re-extracted with the fix in place, and the identical tsauditor scan was re-run against the corrected data. The result: zero ANO001 findings, across 3345 tracked people (down from 3617, since the tracks that consisted mostly of the fake boundary-clamped signal are now correctly excluded rather than silently retained). This before-and-after comparison, same check, same underlying pipeline, only the fix applied in between, is what confirms the fix actually resolved the underlying issue rather than only hiding its symptom.\n",
+    "\n",
+    "### Takeaway\n",
+    "\n",
+    "ANO001 is not a finance-specific or sensor-specific check. The underlying idea, a value that is supposed to vary should not be constant, applies equally to a stock price, a temperature reading, or a joint's position in a video. The specific failure mode found here (a computer vision model clamping instead of failing) looks nothing like a typical financial data quality issue, but it produces the exact same statistical signature that tsauditor was already built to catch.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/examples/opencv-example/tsauditor_opencv_pose_example.ipynb
+++ b/examples/opencv-example/tsauditor_opencv_pose_example.ipynb
@@ -1,0 +1,307 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "OF65oHC2J-mr"
+      },
+      "source": [
+        "# tsauditor Example: Auditing Video Pose Keypoint Time Series\n",
+        "\n",
+        "A non-finance, non-sensor use case: auditing per-person pose keypoint sequences extracted from video (YOLOv8-pose + tracking) for an action recognition pipeline. Each tracked person becomes one panel entity; their per-frame skeleton (17 COCO keypoints, 34 x/y values) is the time series.\n",
+        "\n",
+        "This notebook uses **synthetic data** so it runs standalone. The real case study that motivated this example is described in the markdown cells below.\n"
+      ],
+      "id": "OF65oHC2J-mr"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "RS1AIlDBJ-mv"
+      },
+      "source": [
+        "## 1. Generate synthetic pose data\n",
+        "\n",
+        "Simulates the same shape as real extracted data: some tracks with natural jittery motion, and, deliberately, a few tracks with an injected **boundary-clamp artifact** (a keypoint pinned to a constant value for many consecutive frames), matching the real bug this example is based on.\n"
+      ],
+      "id": "RS1AIlDBJ-mv"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ftYTKvu2J-mv",
+        "outputId": "522be6c6-a852-45d7-a356-6d06ce673b5d"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "20 tracks generated (15 natural, 5 with injected clamp artifact).\n"
+          ]
+        }
+      ],
+      "source": [
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "\n",
+        "np.random.seed(42)\n",
+        "NUM_KEYPOINTS = 17\n",
+        "FPS = 15\n",
+        "\n",
+        "def make_natural_track(n_frames, track_id):\n",
+        "    \"\"\"Normal case: every joint jitters naturally frame to frame.\"\"\"\n",
+        "    base = np.random.uniform(-1, 1, size=(NUM_KEYPOINTS, 2))\n",
+        "    kp = base[None, :, :] + np.random.normal(0, 0.02, size=(n_frames, NUM_KEYPOINTS, 2)).cumsum(axis=0) * 0.1\n",
+        "    return kp\n",
+        "\n",
+        "def make_clamped_track(n_frames, track_id, clamp_joint=15, clamp_value=1.0, clamp_start=10, clamp_len=40):\n",
+        "    \"\"\"Injects the real bug: one joint's y-coordinate gets pinned to a\n",
+        "    constant value for a stretch of frames, mimicking YOLOv8-pose\n",
+        "    clamping an off-screen keypoint to the frame boundary.\"\"\"\n",
+        "    kp = make_natural_track(n_frames, track_id)\n",
+        "    end = min(clamp_start + clamp_len, n_frames)\n",
+        "    kp[clamp_start:end, clamp_joint, 1] = clamp_value  # y-coordinate pinned\n",
+        "    return kp\n",
+        "\n",
+        "frames = {}\n",
+        "\n",
+        "# 15 well-behaved tracks\n",
+        "for i in range(15):\n",
+        "    n = np.random.randint(40, 90)\n",
+        "    kp = make_natural_track(n, i)\n",
+        "    rows = [{\"frame_idx\": t, **{f\"kp{j}_{ax}\": kp[t, j, k]\n",
+        "             for j in range(NUM_KEYPOINTS) for k, ax in enumerate(\"xy\")}}\n",
+        "            for t in range(n)]\n",
+        "    df = pd.DataFrame(rows)\n",
+        "    df[\"timestamp\"] = pd.Timestamp(\"2000-01-01\") + pd.to_timedelta(df[\"frame_idx\"] / FPS, unit=\"s\")\n",
+        "    frames[f\"natural_track_{i}\"] = df.set_index(\"timestamp\").drop(columns=[\"frame_idx\"])\n",
+        "\n",
+        "# 5 tracks with the injected boundary-clamp artifact\n",
+        "for i in range(5):\n",
+        "    n = np.random.randint(50, 90)\n",
+        "    kp = make_clamped_track(n, i)\n",
+        "    rows = [{\"frame_idx\": t, **{f\"kp{j}_{ax}\": kp[t, j, k]\n",
+        "             for j in range(NUM_KEYPOINTS) for k, ax in enumerate(\"xy\")}}\n",
+        "            for t in range(n)]\n",
+        "    df = pd.DataFrame(rows)\n",
+        "    df[\"timestamp\"] = pd.Timestamp(\"2000-01-01\") + pd.to_timedelta(df[\"frame_idx\"] / FPS, unit=\"s\")\n",
+        "    frames[f\"clamped_track_{i}\"] = df.set_index(\"timestamp\").drop(columns=[\"frame_idx\"])\n",
+        "\n",
+        "print(f\"{len(frames)} tracks generated ({15} natural, {5} with injected clamp artifact).\")\n"
+      ],
+      "id": "ftYTKvu2J-mv"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VMLNg1-5J-my"
+      },
+      "source": [
+        "## 2. Audit each track in parallel\n",
+        "\n",
+        "With ~20 short entities (this toy example) or thousands (a real extraction run), `group_col` on one combined long-format frame hits real per-task overhead once entities are numerous and short. Using separate per-entity DataFrames with the documented joblib pattern scales better for this shape of data.\n",
+        "\n",
+        "`target=None` is deliberate: there's no per-frame prediction target here (a track's label, if any, is one scalar for the whole sequence, not per-row), so leakage checks are correctly skipped, not worked around.\n"
+      ],
+      "id": "VMLNg1-5J-my"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 4,
+      "metadata": {
+        "id": "GRg3ECKeJ-mz"
+      },
+      "outputs": [],
+      "source": [
+        "from joblib import Parallel, delayed\n",
+        "import tsauditor as tsa\n",
+        "\n",
+        "def audit_track(track_id, df):\n",
+        "    report = tsa.scan(df, target=None, domain=\"sensor\",\n",
+        "                       run_leakage=False, run_stationarity=False)\n",
+        "    return track_id, report\n",
+        "\n",
+        "results = dict(Parallel(n_jobs=-1)(\n",
+        "    delayed(audit_track)(tid, df) for tid, df in frames.items()\n",
+        "))\n"
+      ],
+      "id": "GRg3ECKeJ-mz"
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install tsauditor"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4Xf13Re8KRpl",
+        "outputId": "cc15d6c8-8278-4111-988c-b2c8b6ae0032"
+      },
+      "id": "4Xf13Re8KRpl",
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Collecting tsauditor\n",
+            "  Downloading tsauditor-0.4.0-py3-none-any.whl.metadata (25 kB)\n",
+            "Requirement already satisfied: pandas<3,>=1.5 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (2.2.2)\n",
+            "Requirement already satisfied: numpy<3,>=1.23 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (2.0.2)\n",
+            "Requirement already satisfied: scipy<2,>=1.9 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (1.16.3)\n",
+            "Requirement already satisfied: statsmodels<1,>=0.13 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (0.14.6)\n",
+            "Requirement already satisfied: rich<16,>=13.0 in /usr/local/lib/python3.12/dist-packages (from tsauditor) (13.9.4)\n",
+            "Requirement already satisfied: python-dateutil>=2.8.2 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2.9.0.post0)\n",
+            "Requirement already satisfied: pytz>=2020.1 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2025.2)\n",
+            "Requirement already satisfied: tzdata>=2022.7 in /usr/local/lib/python3.12/dist-packages (from pandas<3,>=1.5->tsauditor) (2026.3)\n",
+            "Requirement already satisfied: markdown-it-py>=2.2.0 in /usr/local/lib/python3.12/dist-packages (from rich<16,>=13.0->tsauditor) (4.2.0)\n",
+            "Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /usr/local/lib/python3.12/dist-packages (from rich<16,>=13.0->tsauditor) (2.20.0)\n",
+            "Requirement already satisfied: patsy>=0.5.6 in /usr/local/lib/python3.12/dist-packages (from statsmodels<1,>=0.13->tsauditor) (1.0.2)\n",
+            "Requirement already satisfied: packaging>=21.3 in /usr/local/lib/python3.12/dist-packages (from statsmodels<1,>=0.13->tsauditor) (26.2)\n",
+            "Requirement already satisfied: mdurl~=0.1 in /usr/local/lib/python3.12/dist-packages (from markdown-it-py>=2.2.0->rich<16,>=13.0->tsauditor) (0.1.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/dist-packages (from python-dateutil>=2.8.2->pandas<3,>=1.5->tsauditor) (1.17.0)\n",
+            "Downloading tsauditor-0.4.0-py3-none-any.whl (82 kB)\n",
+            "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m82.8/82.8 kB\u001b[0m \u001b[31m3.6 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
+            "\u001b[?25hInstalling collected packages: tsauditor\n",
+            "Successfully installed tsauditor-0.4.0\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "tPUo1OeXJ-mz"
+      },
+      "source": [
+        "## 3. Collect ANO001 (stuck value) findings"
+      ],
+      "id": "tPUo1OeXJ-mz"
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 5,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "XsXdbqNGJ-m0",
+        "outputId": "a9246c9c-fbde-4d24-c12a-ac0e636536a1"
+      },
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "5 ANO001 findings across 20 tracks:\n",
+            "\n",
+            "  clamped_track_0: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+            "  clamped_track_1: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+            "  clamped_track_2: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+            "  clamped_track_3: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n",
+            "  clamped_track_4: Issue(module='anomaly', code='ANO001', severity='warning', description='Stuck values detected.', column='kp15_y', evidence={'max_stuck_duration': 40}, group=None)\n"
+          ]
+        }
+      ],
+      "source": [
+        "stuck = []\n",
+        "for track_id, report in results.items():\n",
+        "    for issue in (report.critical + report.warnings + report.info):\n",
+        "        if \"ANO001\" in str(getattr(issue, \"code\", \"\")):\n",
+        "            stuck.append((track_id, issue))\n",
+        "\n",
+        "print(f\"{len(stuck)} ANO001 findings across {len(frames)} tracks:\\n\")\n",
+        "for track_id, issue in stuck:\n",
+        "    print(f\"  {track_id}: {issue}\")\n"
+      ],
+      "id": "XsXdbqNGJ-m0"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "h2ttoZOVJ-m0"
+      },
+      "source": [
+        "Notice it correctly catches the 5 `clamped_track_*` entities (and correctly leaves the 15 `natural_track_*` entities alone), exactly matching what happened on the real dataset this example is based on.\n"
+      ],
+      "id": "h2ttoZOVJ-m0"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "R11fLaJlJ-m1"
+      },
+      "source": [
+        "## 4. The real case study\n",
+        "\n",
+        "This synthetic example is modeled on a real bug found and fixed while building an unrelated project: a fight and agitation detection pipeline for CCTV monitoring, intended to eventually support detecting sudden aggression in dementia and Parkinson's patients in care settings.\n",
+        "\n",
+        "### Background\n",
+        "\n",
+        "That pipeline extracts human pose keypoints from video using YOLOv8-pose, tracks each person across frames with ByteTrack, and classifies each tracked person's motion sequence with an LSTM as aggressive or calm. Roughly 3600 tracked people were extracted from about 2000 video clips (the RLVS dataset). Each tracked person's keypoints were normalized (centered on hip midpoint, scaled by shoulder width) and cached as a sequence for training.\n",
+        "\n",
+        "### Why tsuditor was applied here\n",
+        "\n",
+        "tsauditor was originally built for financial and sensor time series, not video pose data. It was applied to this pipeline's output anyway, because the underlying data shape is the same regardless of domain: each tracked person is an independent panel entity, and their per-frame keypoints form a time series for that entity. The question TSAuditor answers, is anything in this time series behaving in a way that shouldn't happen, applies just as well to a skeleton's joint position over time as it does to a stock's price over time.\n",
+        "\n",
+        "The specific check of interest was ANO001, stuck value detection. The concern was a known failure mode in this kind of pipeline: if pose tracking silently stalls (loses the person but keeps reporting a value) rather than failing cleanly, the resulting sequence looks like real data but isn't. A frame where every keypoint is exactly zero is easy to catch and already was, but a subtler stall, where the model keeps reporting a plausible-looking but frozen position, is much harder to catch by eye and was not something the pipeline's existing checks looked for.\n",
+        "\n",
+        "### What the audit found\n",
+        "\n",
+        "Each of the roughly 3600 tracked people's keypoint sequences was converted into its own DataFrame and audited independently, in parallel, using the pattern shown in section 2 of this notebook. The scan flagged 1099 ANO001 findings. Nearly all of them were on vertical (y-axis) coordinate columns, and several tracks showed a joint holding the exact same value for over 50 consecutive frames, out of tracks that were themselves often only 50 to 90 frames long. In other words, some tracked people had a joint that never moved for essentially the entire time they were tracked.\n",
+        "\n",
+        "### Investigating the finding\n",
+        "\n",
+        "The first hypothesis was tracking failure: perhaps ByteTrack was losing the person and re-detecting a static background object under the same ID. This was ruled out by inspecting the raw, pre-normalization keypoint values for a flagged track directly, rather than only looking at the normalized, already processed data. The raw dump showed something more specific:\n",
+        "\n",
+        "```\n",
+        "frame 0: kp7(elbow)=[168.95  224]  kp11(hip)=[122.72  224]  kp15(ankle)=[117.84  224]\n",
+        "frame 1: kp7(elbow)=[166.73  224]  kp11(hip)=[122.44  224]  kp15(ankle)=[114.75  224]\n",
+        "frame 2: kp7(elbow)=[165.50  224]  kp11(hip)=[120.85  224]  kp12(hip)=[114.13  224]\n",
+        "...\n",
+        "```\n",
+        "\n",
+        "The x-coordinates were changing naturally, frame to frame, consistent with a real, moving person. The y-coordinates, across several unrelated joints (elbow, both hips, ankle), were pinned to exactly 224. Checking the source video's actual pixel height confirmed it: 224 pixels. That is not a coincidence, it is the frame boundary.\n",
+        "\n",
+        "### Root cause\n",
+        "\n",
+        "YOLOv8-pose, when a tracked person's body extends beyond the visible edge of the frame (a very common situation in close-up or partially cropped CCTV and street-level footage), does not mark the corresponding keypoint as undetected. Instead, it reports a keypoint clamped to the frame boundary, as if that were a normal, confident detection. Because the reported value is a real, non-zero coordinate rather than (0, 0), it passes straight through a simple all-zero detection-failure filter undetected. It also looks fine in a visual sanity check, since a skeleton plot of a single frame with a boundary-clamped ankle still looks like a plausible human pose. The problem only becomes visible when checking whether a value that should vary over time is actually varying, which is exactly what TSAuditor's stuck value check does.\n",
+        "\n",
+        "### Fix\n",
+        "\n",
+        "The pipeline's normalization step was updated to reject any frame where a keypoint sits within about one pixel of the frame boundary, in addition to the existing all-zero check. This is a targeted fix aimed specifically at the confirmed cause, rather than a broader change to tracking or detection logic.\n",
+        "\n",
+        "### Verification\n",
+        "\n",
+        "The full dataset was re-extracted with the fix in place, and the identical tsauditor scan was re-run against the corrected data. The result: zero ANO001 findings, across 3345 tracked people (down from 3617, since the tracks that consisted mostly of the fake boundary-clamped signal are now correctly excluded rather than silently retained). This before-and-after comparison, same check, same underlying pipeline, only the fix applied in between, is what confirms the fix actually resolved the underlying issue rather than only hiding its symptom.\n",
+        "\n",
+        "### Takeaway\n",
+        "\n",
+        "ANO001 is not a finance-specific or sensor-specific check. The underlying idea, a value that is supposed to vary should not be constant, applies equally to a stock price, a temperature reading, or a joint's position in a video. The specific failure mode found here (a computer vision model clamping instead of failing) looks nothing like a typical financial data quality issue, but it produces the exact same statistical signature that tsauditor was already built to catch.\n"
+      ],
+      "id": "R11fLaJlJ-m1"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "colab": {
+      "provenance": []
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary: 
Add example: auditing video pose keypoint time series

Adds a new example notebook demonstrating tsauditor applied to a domain outside its original finance/sensor scope: per-person pose keypoint sequences extracted from video for an action recognition pipeline.

## What's included
A runnable, self-contained notebook using synthetic data (no external dataset or model dependencies required)
Demonstrates the per-entity DataFrame plus joblib.Parallel pattern for auditing many short panel entities, chosen over group_col on a single combined frame due to per-task overhead at this entity count and size
Shows ANO001 (stuck value detection) correctly distinguishing clean tracks from tracks with an injected constant-value artifact
Why this is worth including

This isn't a hypothetical use case. It's modeled directly on a real bug caught while using tsauditor on an unrelated project: a fight and agitation detection pipeline extracting pose data from video. The real audit flagged 1099 ANO001 findings; investigation traced the cause to YOLOv8-pose clamping off-screen keypoints to the frame boundary instead of marking them undetected, a failure mode invisible to both an all-zero detection-failure filter and a visual sanity check. The fix was applied and a re-audit on the corrected data confirmed zero findings. The notebook includes this full narrative as background.

## Notes
No changes to library code, example and documentation only
target=None is used throughout, since leakage detection needs a per-row prediction target that doesn't apply to this data shape (each track has one label for the whole sequence, not a value that varies frame to frame); this is called out explicitly in the notebook so it doesn't read as an oversight